### PR TITLE
Optimize requiring of autoloader

### DIFF
--- a/bin/pcsf-baseline
+++ b/bin/pcsf-baseline
@@ -5,21 +5,20 @@ use Aeliot\PhpCsFixerBaseline\Service\Builder;
 use Aeliot\PhpCsFixerBaseline\Service\Saver;
 
 $autoloaderPath = (static function (): string {
+    if (isset($GLOBALS['_composer_autoload_path'])) {
+        return $GLOBALS['_composer_autoload_path'];
+    }
+
     $paths = [
-        __DIR__ . '/vendor/autoload.php',
+        __DIR__ . '/../../../../vendor/autoload.php',
         __DIR__ . '/../vendor/autoload.php',
         __DIR__ . '/../../vendor/autoload.php',
         __DIR__ . '/../../../vendor/autoload.php',
-        __DIR__ . '/../../../../vendor/autoload.php',
     ];
-
-    if (isset($GLOBALS['_composer_autoload_path'])) {
-        array_unshift($paths, $GLOBALS['_composer_autoload_path']);
-    }
 
     foreach ($paths as $path) {
         if (file_exists($path)) {
-            return realpath($path);
+            return $path;
         }
     }
 


### PR DESCRIPTION
Order of used autoloader:
1. Defined by Composer via `$GLOBALS['_composer_autoload_path']`
2. Relative to installed in consuming (client's) project
3. Relative to self vendors installed on CI
4. +1 and +2 parent's directory with installed vendors (reserved positions)

The first one used if variable is defined. Others used if file exists. Otherwise exception is thrown.