### PR TITLE
Implement update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ chmod +x pcsf-baseline.phar
    ```
 
 ### Using
+
+#### Commands
+
+| Command | Description |
+|---------|-------------|
+| `generate` (default) | Generate or regenerate the full baseline from Finder |
+| `update` | Update hash for files already present in baseline |
+
 1. Generate baseline. Just call script without options when all config files uses default names.
    - Call PHAR
      ```shell
@@ -95,13 +103,18 @@ chmod +x pcsf-baseline.phar
      ```shell
      vendor/bin/pcsf-baseline
      ```
-   See options of it below. You can see how it is configured in this project.
-2. Use PHP CS Fixer as usual. All files mentioned in the baseline will be scip till they are not changed.
+   See options below. You can see how it is configured in this project.
+2. After fixing files with PHP CS Fixer, update their hash in baseline without regenerating it entirely:
+   ```shell
+   vendor/bin/pcsf-baseline update --path src/Foo.php --path src/Bar.php
+   ```
+   The baseline file must already exist. Only files **already listed** in baseline are updated; `config_hash` is not recalculated.
+3. Use PHP CS Fixer as usual. All files mentioned in the baseline will be scip till they are not changed.
 
 This script store relative paths to files in baseline file by default. It is useful when baseline used
 in different environments.
 
-### Options of baseline generator
+### Options of `generate` command
 
 | Short name | Long name | Description                                                          | Default value               |
 |------------|-----------|----------------------------------------------------------------------|-----------------------------|
@@ -121,6 +134,22 @@ filter factory.
 
 Pass option `absolute` when you want to force saving of absolute paths to files of your project in baseline.
 It cannot be used with option `workdir`.
+
+### Options of `update` command
+
+| Short name | Long name | Description | Default value |
+|------------|-----------|-------------|---------------|
+| a | absolute | Baseline uses absolute paths (must match existing baseline) | |
+| b | baseline | Pathname of baseline file | .php-cs-fixer-baseline.json |
+| d | config-dir | Config files path prefix | '' |
+| w | workdir | Working directory | |
+| p | path | Path to file already in baseline (**repeatable**, required) | |
+
+Example:
+
+```shell
+vendor/bin/pcsf-baseline update -p src/Service/Foo.php -p src/Service/Bar.php
+```
 
 ### Restrictions for using of relative paths
 1. Option `workdir` MUST be absolute. You cannot use "double dots" in it.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,7 @@ services:
       - '../src/Console/ContainerBuilder.php'
       - '../src/Model'
 
-  Aeliot\PhpCsFixerBaseline\Console\Command\GenerateCommand:
+  Aeliot\PhpCsFixerBaseline\Console\Command\:
     public: true
+    resource: '../src/Console/Command/*'
     tags: ['console.command']

--- a/src/Console/Command/UpdateCommand.php
+++ b/src/Console/Command/UpdateCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the PHP CS Fixer Baseline project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\PhpCsFixerBaseline\Console\Command;
+
+use Aeliot\PhpCsFixerBaseline\Service\BuilderConfigFactory;
+use Aeliot\PhpCsFixerBaseline\Service\Saver;
+use Aeliot\PhpCsFixerBaseline\Service\Updater;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+#[AsCommand(name: 'update', description: 'Update hash for files already in baseline')]
+final class UpdateCommand extends Command
+{
+    public function __construct(
+        private readonly BuilderConfigFactory $builderConfigFactory,
+        private readonly Updater $updater,
+        private readonly Saver $saver,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'absolute',
+                'a',
+                InputOption::VALUE_NONE,
+                'Store absolute paths in baseline file',
+            )
+            ->addOption(
+                'baseline',
+                'b',
+                InputOption::VALUE_REQUIRED,
+                'Pathname of baseline file',
+                '.php-cs-fixer-baseline.json',
+            )
+            ->addOption(
+                'config-dir',
+                'd',
+                InputOption::VALUE_REQUIRED,
+                'Config files path',
+                '',
+            )
+            ->addOption(
+                'workdir',
+                'w',
+                InputOption::VALUE_REQUIRED,
+                'Working directory',
+            )
+            ->addOption(
+                'path',
+                'p',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Path to file already in baseline (repeatable)',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var list<string>|null $filePaths */
+        $filePaths = $input->getOption('path');
+
+        if (null === $filePaths || [] === $filePaths) {
+            throw new \InvalidArgumentException('At least one --path is required.');
+        }
+
+        $context = $this->builderConfigFactory->resolveBaselineOptions($input);
+        $baseline = $this->updater->update($context, $filePaths);
+        $this->saver->save($baseline);
+        $output->writeln(\sprintf('Ok, %d file(s) updated in baseline', \count($filePaths)));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Service/BuilderConfigFactory.php
+++ b/src/Service/BuilderConfigFactory.php
@@ -23,12 +23,10 @@ final class BuilderConfigFactory
     public function createFromInput(InputInterface $input): BuilderConfig
     {
         $rootDirectory = $this->getStringOption($input, 'config-dir', '');
+        $baselineOptions = $this->resolveBaselineOptions($input);
 
         return new BuilderConfig([
-            'baselinePath' => $this->resolvePath(
-                $rootDirectory,
-                $this->getStringOption($input, 'baseline', '.php-cs-fixer-baseline.json'),
-            ),
+            'baselinePath' => $baselineOptions['baselinePath'],
             'config' => $this->loadConfig(
                 $rootDirectory,
                 $this->getStringOption($input, 'config', '.php-cs-fixer.dist.php'),
@@ -37,9 +35,26 @@ final class BuilderConfigFactory
                 $rootDirectory,
                 $this->getStringOption($input, 'finder', '.php-cs-fixer-finder.php'),
             ),
+            'relative' => $baselineOptions['relative'],
+            'workdir' => $baselineOptions['workdir'],
+        ]);
+    }
+
+    /**
+     * @return array{baselinePath: string, relative: bool, workdir: ?string}
+     */
+    public function resolveBaselineOptions(InputInterface $input): array
+    {
+        $rootDirectory = $this->getStringOption($input, 'config-dir', '');
+
+        return [
+            'baselinePath' => $this->resolvePath(
+                $rootDirectory,
+                $this->getStringOption($input, 'baseline', '.php-cs-fixer-baseline.json'),
+            ),
             'relative' => !$input->getOption('absolute'),
             'workdir' => $this->getNullableStringOption($input, 'workdir'),
-        ]);
+        ];
     }
 
     private function getNullableStringOption(InputInterface $input, string $name): ?string

--- a/src/Service/Updater.php
+++ b/src/Service/Updater.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the PHP CS Fixer Baseline project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\PhpCsFixerBaseline\Service;
+
+use Aeliot\PhpCsFixerBaseline\Model\BaselineFile;
+use Aeliot\PhpCsFixerBaseline\Model\FileHash;
+
+final class Updater
+{
+    public function __construct(
+        private readonly Reader $reader = new Reader(),
+        private readonly FileCacheCalculator $fileCacheCalculator = new FileCacheCalculator(),
+    ) {
+    }
+
+    /**
+     * @param array{baselinePath: string, relative: bool, workdir: ?string} $context
+     * @param list<string> $filePaths
+     */
+    public function update(array $context, array $filePaths): BaselineFile
+    {
+        $baselinePath = $context['baselinePath'];
+
+        if (!file_exists($baselinePath)) {
+            throw new \InvalidArgumentException(\sprintf('Baseline file "%s" does not exist.', $baselinePath));
+        }
+
+        $baselineFile = $this->reader->read($baselinePath);
+        $content = $baselineFile->getContent();
+
+        if ($content->isRelative()) {
+            $content->setWorkdir($context['workdir'] ?? getcwd());
+        }
+
+        foreach ($filePaths as $filePath) {
+            $absolutePath = realpath($filePath);
+
+            if (false === $absolutePath || !is_file($absolutePath)) {
+                throw new \InvalidArgumentException(\sprintf('File "%s" does not exist.', $filePath));
+            }
+
+            $existing = $content->getHash($absolutePath);
+
+            if (null === $existing) {
+                throw new \InvalidArgumentException(\sprintf('File "%s" is not in baseline.', $filePath));
+            }
+
+            $hash = $this->fileCacheCalculator->calculate(new \SplFileInfo($absolutePath));
+            $content->addHash(new FileHash($existing->getPath(), $hash));
+        }
+
+        return $baselineFile;
+    }
+}

--- a/tests/config/.php-cs-fixer-finder.php
+++ b/tests/config/.php-cs-fixer-finder.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 return $finder = (new PhpCsFixer\Finder())
     ->files()
-    ->name('file-for-calculation-of-hash.php')
+    ->name([
+        'file-for-calculation-of-hash.php',
+        'file-for-calculation-of-hash-second.php',
+    ])
     ->in(__DIR__ . '/../fixtures/');
 
 

--- a/tests/fixtures/file-for-calculation-of-hash-second.php
+++ b/tests/fixtures/file-for-calculation-of-hash-second.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Second file for the calculation of hash
+ */
+declare(strict_types=1);

--- a/tests/functional/ApplicationTest.php
+++ b/tests/functional/ApplicationTest.php
@@ -15,7 +15,9 @@ namespace Aeliot\PhpCsFixerBaseline\Test\Functional;
 
 use Aeliot\PhpCsFixerBaseline\Console\Application;
 use Aeliot\PhpCsFixerBaseline\Console\Command\GenerateCommand;
+use Aeliot\PhpCsFixerBaseline\Console\Command\UpdateCommand;
 use Aeliot\PhpCsFixerBaseline\Console\ContainerBuilder;
+use Aeliot\PhpCsFixerBaseline\Service\FileCacheCalculator;
 use Aeliot\PhpCsFixerBaseline\Service\FilterFactory;
 use PhpCsFixer\Config;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -31,11 +33,19 @@ final class ApplicationTest extends TestCase
     private string $projectRoot;
 
     private string $baselinePath;
+    private string $firstFixtureFile;
+    private string $firstFixtureOriginalContent;
+    private string $secondFixtureFile;
+    private string $secondFixtureOriginalContent;
 
     protected function setUp(): void
     {
         $this->projectRoot = \dirname(__DIR__, 2);
         $this->baselinePath = $this->projectRoot . '/tests/config/.php-cs-fixer-baseline.json';
+        $this->firstFixtureFile = $this->projectRoot . '/tests/fixtures/file-for-calculation-of-hash.php';
+        $this->firstFixtureOriginalContent = (string) file_get_contents($this->firstFixtureFile);
+        $this->secondFixtureFile = $this->projectRoot . '/tests/fixtures/file-for-calculation-of-hash-second.php';
+        $this->secondFixtureOriginalContent = (string) file_get_contents($this->secondFixtureFile);
 
         if (file_exists($this->baselinePath)) {
             unlink($this->baselinePath);
@@ -47,6 +57,9 @@ final class ApplicationTest extends TestCase
         if (file_exists($this->baselinePath)) {
             unlink($this->baselinePath);
         }
+
+        file_put_contents($this->firstFixtureFile, $this->firstFixtureOriginalContent);
+        file_put_contents($this->secondFixtureFile, $this->secondFixtureOriginalContent);
     }
 
     public function testContainerBuildsAndProvidesGenerateCommand(): void
@@ -63,12 +76,105 @@ final class ApplicationTest extends TestCase
 
         self::assertSame(0, $exitCode);
         self::assertFileExists($this->baselinePath);
-        self::assertStringContainsString('Ok, 1 files added to baseline', $output);
+        self::assertStringContainsString('Ok, 2 files added to baseline', $output);
 
         $content = json_decode((string) file_get_contents($this->baselinePath), true, 512, \JSON_THROW_ON_ERROR);
         self::assertArrayHasKey('config_hash', $content);
         self::assertArrayHasKey('hashes', $content);
-        self::assertCount(1, $content['hashes']);
+        self::assertCount(2, $content['hashes']);
+    }
+
+    public function testContainerBuildsAndProvidesUpdateCommand(): void
+    {
+        $container = ContainerBuilder::build();
+
+        self::assertTrue($container->has(UpdateCommand::class));
+        self::assertInstanceOf(UpdateCommand::class, $container->get(UpdateCommand::class));
+    }
+
+    public function testUpdateCommandRunsSuccessfully(): void
+    {
+        $this->runGenerateCommand();
+        file_put_contents($this->firstFixtureFile, $this->firstFixtureOriginalContent . "\n");
+
+        [$exitCode, $output] = $this->runUpdateCommand([$this->firstFixtureFile]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Ok, 1 file(s) updated in baseline', $output);
+
+        /** @var Config $config */
+        $config = require $this->projectRoot . '/tests/config/.php-cs-fixer.dist.php';
+
+        $filter = (new FilterFactory())->createFilter($this->baselinePath, $config);
+        $file = new \SplFileInfo((string) realpath($this->firstFixtureFile));
+
+        self::assertFalse($filter($file));
+    }
+
+    public function testUpdateCommandUpdatesOnlyRequestedFile(): void
+    {
+        $this->runGenerateCommand();
+        $baselineBeforeUpdate = $this->readBaselineHashes();
+        $secondFileBaselineKey = 'tests/fixtures/file-for-calculation-of-hash-second.php';
+        self::assertArrayHasKey($secondFileBaselineKey, $baselineBeforeUpdate);
+
+        file_put_contents($this->firstFixtureFile, $this->firstFixtureOriginalContent . "\n// changed first\n");
+        file_put_contents($this->secondFixtureFile, $this->secondFixtureOriginalContent . "\n// changed second\n");
+
+        [$exitCode, $output] = $this->runUpdateCommand([$this->firstFixtureFile]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Ok, 1 file(s) updated in baseline', $output);
+
+        $baselineAfterUpdate = $this->readBaselineHashes();
+        $calculator = new FileCacheCalculator();
+
+        self::assertSame(
+            $calculator->calculate(new \SplFileInfo((string) realpath($this->firstFixtureFile))),
+            $baselineAfterUpdate['tests/fixtures/file-for-calculation-of-hash.php'],
+        );
+        self::assertSame(
+            $baselineBeforeUpdate[$secondFileBaselineKey],
+            $baselineAfterUpdate[$secondFileBaselineKey],
+        );
+        self::assertNotSame(
+            $calculator->calculate(new \SplFileInfo((string) realpath($this->secondFixtureFile))),
+            $baselineAfterUpdate[$secondFileBaselineKey],
+        );
+    }
+
+    public function testUpdateCommandUpdatesTwoFilesInOneCall(): void
+    {
+        $this->runGenerateCommand();
+        $baselineBeforeUpdate = $this->readBaselineHashes();
+
+        file_put_contents($this->firstFixtureFile, $this->firstFixtureOriginalContent . "\n// changed first\n");
+        file_put_contents($this->secondFixtureFile, $this->secondFixtureOriginalContent . "\n// changed second\n");
+
+        [$exitCode, $output] = $this->runUpdateCommand([$this->firstFixtureFile, $this->secondFixtureFile]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Ok, 2 file(s) updated in baseline', $output);
+
+        $baselineAfterUpdate = $this->readBaselineHashes();
+        $calculator = new FileCacheCalculator();
+
+        self::assertSame(
+            $calculator->calculate(new \SplFileInfo((string) realpath($this->firstFixtureFile))),
+            $baselineAfterUpdate['tests/fixtures/file-for-calculation-of-hash.php'],
+        );
+        self::assertSame(
+            $calculator->calculate(new \SplFileInfo((string) realpath($this->secondFixtureFile))),
+            $baselineAfterUpdate['tests/fixtures/file-for-calculation-of-hash-second.php'],
+        );
+        self::assertNotSame(
+            $baselineBeforeUpdate['tests/fixtures/file-for-calculation-of-hash.php'],
+            $baselineAfterUpdate['tests/fixtures/file-for-calculation-of-hash.php'],
+        );
+        self::assertNotSame(
+            $baselineBeforeUpdate['tests/fixtures/file-for-calculation-of-hash-second.php'],
+            $baselineAfterUpdate['tests/fixtures/file-for-calculation-of-hash-second.php'],
+        );
     }
 
     public function testFilterFactoryExcludesBaselineFileWhenConfigMatches(): void
@@ -102,6 +208,19 @@ final class ApplicationTest extends TestCase
     }
 
     /**
+     * @return array<string, int>
+     */
+    private function readBaselineHashes(): array
+    {
+        $content = json_decode((string) file_get_contents($this->baselinePath), true, 512, \JSON_THROW_ON_ERROR);
+
+        return array_map(
+            static fn (array $entry): int => $entry['hash'],
+            $content['hashes'],
+        );
+    }
+
+    /**
      * @return array{0: int, 1: string}
      */
     private function runGenerateCommand(): array
@@ -114,6 +233,30 @@ final class ApplicationTest extends TestCase
         $output = new BufferedOutput();
         $exitCode = $application->run(
             new ArrayInput(['--config-dir' => 'tests/config/']),
+            $output,
+        );
+
+        return [$exitCode, $output->fetch()];
+    }
+
+    /**
+     * @param list<string> $paths
+     *
+     * @return array{0: int, 1: string}
+     */
+    private function runUpdateCommand(array $paths): array
+    {
+        $container = ContainerBuilder::build();
+        $application = new Application($container);
+        $application->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(
+            new ArrayInput([
+                'command' => 'update',
+                '--config-dir' => 'tests/config/',
+                '--path' => $paths,
+            ]),
             $output,
         );
 

--- a/tests/unit/Service/UpdaterTest.php
+++ b/tests/unit/Service/UpdaterTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the PHP CS Fixer Baseline project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\PhpCsFixerBaseline\Test\Unit\Service;
+
+use Aeliot\PhpCsFixerBaseline\Service\FileCacheCalculator;
+use Aeliot\PhpCsFixerBaseline\Service\Updater;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Updater::class)]
+final class UpdaterTest extends TestCase
+{
+    private string $fixtureFile;
+
+    /** @var list<string> */
+    private array $temporaryFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->fixtureFile = (string) realpath(__DIR__ . '/../../fixtures/file-for-calculation-of-hash.php');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $temporaryFile) {
+            if (file_exists($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
+    }
+
+    public function testUpdateOneFileInAbsoluteBaseline(): void
+    {
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1624530864,
+            'relative' => false,
+            'hashes' => [
+                $this->fixtureFile => ['hash' => 0],
+            ],
+        ]);
+        $originalContent = (string) file_get_contents($this->fixtureFile);
+        file_put_contents($this->fixtureFile, $originalContent . "\n");
+
+        try {
+            $baselineFile = (new Updater())->update(
+                [
+                    'baselinePath' => $baselinePath,
+                    'relative' => false,
+                    'workdir' => null,
+                ],
+                [$this->fixtureFile],
+            );
+
+            $fileHash = $baselineFile->getContent()->getHash($this->fixtureFile);
+            self::assertNotNull($fileHash);
+            self::assertSame(
+                (new FileCacheCalculator())->calculate(new \SplFileInfo($this->fixtureFile)),
+                $fileHash->getHash(),
+            );
+            self::assertSame(1624530864, $baselineFile->getContent()->getConfigHash());
+        } finally {
+            file_put_contents($this->fixtureFile, $originalContent);
+        }
+    }
+
+    public function testUpdateTwoFilesInOneCall(): void
+    {
+        $firstFile = $this->createTemporaryPhpFile('first');
+        $secondFile = $this->createTemporaryPhpFile('second');
+        $calculator = new FileCacheCalculator();
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1,
+            'relative' => false,
+            'hashes' => [
+                $firstFile => ['hash' => 0],
+                $secondFile => ['hash' => 0],
+            ],
+        ]);
+
+        file_put_contents($firstFile, "<?php\n// changed\n");
+        file_put_contents($secondFile, "<?php\n// changed too\n");
+
+        $baselineFile = (new Updater())->update(
+            [
+                'baselinePath' => $baselinePath,
+                'relative' => false,
+                'workdir' => null,
+            ],
+            [$firstFile, $secondFile],
+        );
+
+        self::assertSame(2, $baselineFile->getContent()->getHashesCount());
+        self::assertSame(
+            $calculator->calculate(new \SplFileInfo($firstFile)),
+            $baselineFile->getContent()->getHash($firstFile)?->getHash(),
+        );
+        self::assertSame(
+            $calculator->calculate(new \SplFileInfo($secondFile)),
+            $baselineFile->getContent()->getHash($secondFile)?->getHash(),
+        );
+    }
+
+    public function testOverwriteExistingEntryDoesNotIncreaseCount(): void
+    {
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1,
+            'relative' => false,
+            'hashes' => [
+                $this->fixtureFile => ['hash' => 0],
+            ],
+        ]);
+        $originalContent = (string) file_get_contents($this->fixtureFile);
+        file_put_contents($this->fixtureFile, $originalContent . "\n");
+
+        try {
+            $baselineFile = (new Updater())->update(
+                [
+                    'baselinePath' => $baselinePath,
+                    'relative' => false,
+                    'workdir' => null,
+                ],
+                [$this->fixtureFile],
+            );
+
+            self::assertSame(1, $baselineFile->getContent()->getHashesCount());
+        } finally {
+            file_put_contents($this->fixtureFile, $originalContent);
+        }
+    }
+
+    public function testFileNotInBaselineThrowsException(): void
+    {
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1,
+            'relative' => false,
+            'hashes' => [],
+        ]);
+        $anotherFile = $this->createTemporaryPhpFile('outside-baseline');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not in baseline');
+
+        (new Updater())->update(
+            [
+                'baselinePath' => $baselinePath,
+                'relative' => false,
+                'workdir' => null,
+            ],
+            [$anotherFile],
+        );
+    }
+
+    public function testRelativeBaselineWithWorkdir(): void
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $relativePath = 'tests/fixtures/file-for-calculation-of-hash.php';
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1,
+            'relative' => true,
+            'hashes' => [
+                $relativePath => ['hash' => 0],
+            ],
+        ]);
+        $originalContent = (string) file_get_contents($this->fixtureFile);
+        file_put_contents($this->fixtureFile, $originalContent . "\n");
+
+        try {
+            $baselineFile = (new Updater())->update(
+                [
+                    'baselinePath' => $baselinePath,
+                    'relative' => true,
+                    'workdir' => $projectRoot,
+                ],
+                [$this->fixtureFile],
+            );
+
+            $fileHash = $baselineFile->getContent()->getHash($this->fixtureFile);
+            self::assertNotNull($fileHash);
+            self::assertSame($relativePath, $fileHash->getPath());
+        } finally {
+            file_put_contents($this->fixtureFile, $originalContent);
+        }
+    }
+
+    public function testNonExistentFileThrowsException(): void
+    {
+        $baselinePath = $this->createTemporaryBaseline([
+            'config_hash' => 1,
+            'relative' => false,
+            'hashes' => [
+                $this->fixtureFile => ['hash' => 4266623405],
+            ],
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        (new Updater())->update(
+            [
+                'baselinePath' => $baselinePath,
+                'relative' => false,
+                'workdir' => null,
+            ],
+            ['/path/to/non-existent-file.php'],
+        );
+    }
+
+    public function testNonExistentBaselineThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Baseline file');
+
+        (new Updater())->update(
+            [
+                'baselinePath' => sys_get_temp_dir() . '/missing-baseline.json',
+                'relative' => false,
+                'workdir' => null,
+            ],
+            [$this->fixtureFile],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createTemporaryBaseline(array $data): string
+    {
+        $path = sys_get_temp_dir() . '/pcsf-baseline-' . uniqid('', true) . '.json';
+        $this->temporaryFiles[] = $path;
+        file_put_contents($path, (string) json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));
+
+        return $path;
+    }
+
+    private function createTemporaryPhpFile(string $suffix): string
+    {
+        $path = sys_get_temp_dir() . '/pcsf-file-' . $suffix . '-' . uniqid('', true) . '.php';
+        $this->temporaryFiles[] = $path;
+        file_put_contents($path, "<?php\n// {$suffix}\n");
+
+        return $path;
+    }
+}


### PR DESCRIPTION
### Options of `update` command

| Short name | Long name | Description | Default value |
|------------|-----------|-------------|---------------|
| a | absolute | Baseline uses absolute paths (must match existing baseline) | |
| b | baseline | Pathname of baseline file | .php-cs-fixer-baseline.json |
| d | config-dir | Config files path prefix | '' |
| w | workdir | Working directory | |
| p | path | Path to file already in baseline (**repeatable**, required) | |

Example:

```shell
vendor/bin/pcsf-baseline update -p src/Service/Foo.php -p src/Service/Bar.php
```

> Closes #22